### PR TITLE
Update `grammar.md`: double-colon is used for nested resource access

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -114,7 +114,7 @@ memberExpression ->
   memberExpression "[" expression "]" |
   memberExpression "." IDENTIFIER(property) |
   memberExpression "." functionCall |
-  memberExpression ":" IDENTIFIER(name) |
+  memberExpression "::" IDENTIFIER(name) |
   memberExpression "!"
 
 primaryExpression ->


### PR DESCRIPTION
Since Bicep [v0.3.216](https://github.com/Azure/bicep/releases/tag/v0.3.126) nested resources are accessed with a double-colon instead of a single colon. That change (https://github.com/Azure/bicep/pull/1815) hasn't been reflected in the grammar description in `grammar.md`. This PR fixes this.